### PR TITLE
Update ansible to 2.9.6 and alpine to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-MAINTAINER zoltan@mullner.hu
+LABEL maintainer="zoltan@mullner.hu"
 
 RUN echo "===> Installing sudo to emulate normal OS behavior..."  && \
     apk --update add sudo                                         && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 
 MAINTAINER zoltan@mullner.hu
 
@@ -14,7 +14,7 @@ RUN echo "===> Installing sudo to emulate normal OS behavior..."  && \
     \
     \
     echo "===> Installing Ansible..."  && \
-    pip3 install ansible==2.9.1         && \
+    pip3 install ansible==2.9.6         && \
     \
     \
     echo "===> Installing handy tools (not absolutely required)..."  && \


### PR DESCRIPTION
Hey, I needed a fix in ansible 2.9.6 so did an update (also of the alpine image). While doing this I discovered that `MAINTAINER` is [deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) and replaced it with a label.

It's running without any problems for me  for some time now.

Would be great to see this in the docker hub in the future, thanks!